### PR TITLE
fix: enable multiplatform docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          uses: linux/amd64,linux/arm64
           file: docker/Dockerfile
           pull: true
           push: true


### PR DESCRIPTION
This [should](https://github.com/docker/build-push-action/issues/302) fix it.
Can we test the change?